### PR TITLE
Change message in case of authentication failure

### DIFF
--- a/src/main/java/edu/kpi/testcourse/auth/AuthenticationProviderUserPassword.java
+++ b/src/main/java/edu/kpi/testcourse/auth/AuthenticationProviderUserPassword.java
@@ -50,7 +50,9 @@ public class AuthenticationProviderUserPassword implements AuthenticationProvide
           .onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()));
         emitter.onComplete();
       } else {
-        emitter.onError(new AuthenticationException(new AuthenticationFailed()));
+        emitter.onError(
+            new AuthenticationException(new AuthenticationFailed("Wrong username or password"))
+        );
       }
     }, BackpressureStrategy.ERROR);
   }


### PR DESCRIPTION
This PR changes message from "Unknown" to "Wrong username or password" in case of failed authentication.