### PR TITLE
Change response if email is already in use

### DIFF
--- a/src/main/java/edu/kpi/testcourse/controller/UserController.java
+++ b/src/main/java/edu/kpi/testcourse/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
 
   @Post("/signup")
   @Secured(SecurityRule.IS_ANONYMOUS)
-  HttpResponse<?> signUp(@Valid @Body User user) throws Exception {
+  HttpResponse<?> signUp(@Valid @Body User user) {
     logger.info("Processing POST /users/signup request");
     userService.registerUser(user);
     return HttpResponse.status(HttpStatus.CREATED);

--- a/src/main/java/edu/kpi/testcourse/exception/UserAlreadyExists.java
+++ b/src/main/java/edu/kpi/testcourse/exception/UserAlreadyExists.java
@@ -1,0 +1,10 @@
+package edu.kpi.testcourse.exception;
+
+/**
+ * Exception that occurs when the user already exists in the system.
+ */
+public class UserAlreadyExists extends RuntimeException {
+  public UserAlreadyExists() {
+    super("Email is already used");
+  }
+}

--- a/src/main/java/edu/kpi/testcourse/exception/UserAlreadyExistsHandler.java
+++ b/src/main/java/edu/kpi/testcourse/exception/UserAlreadyExistsHandler.java
@@ -1,0 +1,24 @@
+package edu.kpi.testcourse.exception;
+
+import edu.kpi.testcourse.model.ErrorResponse;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import javax.inject.Singleton;
+
+/**
+ * Handler of {@link UserAlreadyExists} exception.
+ */
+@Produces
+@Singleton
+@Requires(classes = {UserAlreadyExists.class, ExceptionHandler.class})
+public class UserAlreadyExistsHandler implements
+    ExceptionHandler<UserAlreadyExists, HttpResponse<ErrorResponse>> {
+
+  @Override
+  public HttpResponse<ErrorResponse> handle(HttpRequest request, UserAlreadyExists exception) {
+    return HttpResponse.badRequest(new ErrorResponse(2, exception.getMessage()));
+  }
+}

--- a/src/main/java/edu/kpi/testcourse/logic/UserService.java
+++ b/src/main/java/edu/kpi/testcourse/logic/UserService.java
@@ -1,5 +1,6 @@
 package edu.kpi.testcourse.logic;
 
+import edu.kpi.testcourse.exception.UserAlreadyExists;
 import edu.kpi.testcourse.model.User;
 import edu.kpi.testcourse.repository.UserRepository;
 import javax.inject.Inject;
@@ -24,11 +25,10 @@ public class UserService {
    * Performs user registration.
    *
    * @param user who wants to register
-   * @throws Exception if user is already registered
    */
-  public void registerUser(User user) throws Exception {
+  public void registerUser(User user) {
     if (userRepository.containsUserWithEmail(user.getEmail())) {
-      throw new Exception(String.format("User with email='%s' already exists", user.getEmail()));
+      throw new UserAlreadyExists();
     }
     user.setPassword(passwordEncoder.encode(user.getPassword()));
     userRepository.save(user);

--- a/src/test/java/edu/kpi/testcourse/controller/UserControllerTest.java
+++ b/src/test/java/edu/kpi/testcourse/controller/UserControllerTest.java
@@ -2,11 +2,13 @@ package edu.kpi.testcourse.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.kpi.testcourse.model.ErrorResponse;
 import edu.kpi.testcourse.model.User;
 import edu.kpi.testcourse.repository.UserRepository;
 import edu.kpi.testcourse.repository.UserRepositoryImpl;
@@ -18,6 +20,7 @@ import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import java.util.Optional;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -56,7 +59,11 @@ class UserControllerTest {
       .exchange(HttpRequest.POST("/users/signup", user), String.class);
 
     HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, e);
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, thrown.getStatus());
+    assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+    Optional<ErrorResponse> responseBody = thrown.getResponse().getBody(ErrorResponse.class);
+    assertTrue(responseBody.isPresent(), "The response body must not be null");
+    assertEquals(2, responseBody.get().reasonCode());
+    assertEquals("Email is already used", responseBody.get().reasonText());
     verify(userRepository, never()).save(user);
   }
 }

--- a/src/test/java/edu/kpi/testcourse/logic/UserServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.kpi.testcourse.exception.UserAlreadyExists;
 import edu.kpi.testcourse.model.User;
 import edu.kpi.testcourse.repository.UserRepository;
 import edu.kpi.testcourse.repository.UserRepositoryImpl;
@@ -47,8 +48,8 @@ class UserServiceTest {
 
     Executable e = () -> userService.registerUser(user);
 
-    Exception exception = assertThrows(Exception.class, e);
-    assertThat(exception.getMessage()).contains("User with email='user' already exists");
+    UserAlreadyExists exception = assertThrows(UserAlreadyExists.class, e);
+    assertThat(exception.getMessage()).contains("Email is already used");
     verify(userRepository, never()).save(user);
   }
 }


### PR DESCRIPTION
This PR changes the response when email is already in use and the user wants to register a new account.
In this case, the response must be:
`{"reason_code" : 2,
"reason_text" : "Email is already used"}`